### PR TITLE
Apparently a bug

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         networks:
             - licensewatch
     mariadb:
-        image: mariadb:10.5.2
+        image: mariadb:10.5.5
         volumes:
             - mariadb-volume:/var/lib/mysql
         environment:


### PR DESCRIPTION
[From here](https://serverfault.com/questions/1036047/note-usr-sbin-mysqld-initiated-by-unknown-normal-shutdown#comment1348814_1036047):

Per [jira.mariadb.org/browse/MDEV-20261](https://jira.mariadb.org/browse/MDEV-20261), this was introduced in 10.4 and fixed in 10.5.5 so any version <10.4,>=10.5.5 should do. Given this is 10.3 I'm assuming it's not even the same bug.