### PR TITLE
Update config.pm

### DIFF
--- a/vagrant_provision/pl/config.pm
+++ b/vagrant_provision/pl/config.pm
@@ -32,7 +32,7 @@ our $COMPOSER_PACKAGES = "vendor";
 our @COMPOSER_CODE_FILES = qw(*);
 
 # Packages needed for phplw.
-our @REQUIRED_PACKAGES = ("apache2", "php", "php-mysql", "mysql-server", "mysql-client", "lsb", "wget", "zip", "unzip","composer");
+our @REQUIRED_PACKAGES = ("apache2", "php", "php-mysql", "mysql-server", "mysql-client", "lsb", "wget", "zip", "unzip");
 
 # Non super user account.  Some package systems run better when not as root.
 our $VAGRANT_USER = "vagrant";


### PR DESCRIPTION
Composer already had a complete install and setup subroutine.  Adding it to `@REQUIRED_PACKAGES` would create a second install via aptitude, probably of a different version and potentially conflicting version.

Historically, my first attempt at implementing Composer was to get it from Canonical via aptitude, but (at the time) their version was so old, that it was showing a deprecation warning on itself.  So I wrote the subroutine to ensure that the Vagrant VM, when built, has the latest version of Composer.

q.v.  Existing setup code
https://github.com/phpLicenseWatcher/phpLicenseWatcher/blob/ebb073a52ca2ddea456c06fcc8c39a186a2f4740/vagrant_provision/pl/provision.pl#L274-L305

q.v.  Existing setup config
https://github.com/phpLicenseWatcher/phpLicenseWatcher/blob/ebb073a52ca2ddea456c06fcc8c39a186a2f4740/vagrant_provision/pl/config.pm#L76-L82